### PR TITLE
1.8.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,39 @@
+# Javascript Node CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-javascript/ for more details
+#
+version: 2
+jobs:
+  build:
+    docker:
+      # specify the version you desire here
+      - image: circleci/node:6.10.3
+
+      # Specify service dependencies here if necessary
+      # CircleCI maintains a library of pre-built images
+      # documented at https://circleci.com/docs/2.0/circleci-images/
+      # - image: circleci/mongo:3.4.4
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "package.json" }}
+          # fallback to using the latest cache if no exact match is found
+          - v1-dependencies-
+
+      - run: npm install
+
+      - save_cache:
+          paths:
+            - node_modules
+          key: v1-dependencies-{{ checksum "package.json" }}
+
+      # run tests!
+      - run: node --version
+      - run: npm --version
+      - run: npm test

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,22 @@
+pipeline {
+  agent  {
+    label 'osx'
+  }
+  stages {
+    stage('NPM install and test') {
+      steps {
+        timeout(60) {
+          sh 'npm install'
+          sh 'node --version'
+          sh 'npm --version'
+          sh 'npm test'
+        }
+      }
+      post {
+        always {
+          cleanWs()
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-mksnapshot",
-  "version": "1.7.1",
+  "version": "1.8.0",
   "description": "Electron version of the mksnapshot binary",
   "repository": "https://github.com/electron/mksnapshot",
   "bin": {

--- a/test/mksnapshot-test.js
+++ b/test/mksnapshot-test.js
@@ -25,10 +25,10 @@ describe('mksnapshot binary', function () {
     mksnapshot.stderr.on('data', function (data) { output += data })
 
     mksnapshot.on('close', function (code) {
-      assert.equal(typeof code, 'number')
-      assert.equal(code, 0)
-      assert.equal(output.indexOf('Loading script for embedding'), 0, output)
-      assert.equal(fs.existsSync(outputFile), true)
+      assert.equal(typeof code, 'number', 'Exit code is a number')
+      assert.equal(code, 0, 'Exit code is not zero')
+      assert.equal(output.indexOf('Loading script for embedding'), 0, output, 'Output is correct')
+      assert.equal(fs.existsSync(outputFile), true, 'Output file exists.')
       done()
     })
 
@@ -50,10 +50,10 @@ describe('mksnapshot binary', function () {
     mksnapshot.stderr.on('data', function (data) { output += data })
 
     mksnapshot.on('close', function (code) {
-      assert.equal(typeof code, 'number')
-      assert.notEqual(code, 0)
-      assert.notEqual(output.indexOf('Fatal error'), -1, output)
-      assert.equal(fs.existsSync(outputFile), true)
+      assert.equal(typeof code, 'number', 'Exit code is a number')
+      assert.notEqual(code, 0, 'Exit code is not zero')
+      assert.notEqual(output.indexOf('Fatal error'), -1, 'Output has fatal error')
+      assert.equal(fs.existsSync(outputFile), false, 'Output file does not exist.')
       done()
     })
 


### PR DESCRIPTION
Updated for 1.8

Added testing for mac and linux

Add messages to asserts

Fix invalid file test

mksnapshot no longer generates files for invalid files.  See https://chromium.googlesource.com/v8/v8.git/+/0b90e985f736cae797b23969e6e53e303f018236%5E%21/#F0 for more details