### PR TITLE
electron v1.8.2 is released

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-mksnapshot",
-  "version": "1.8.0",
+  "version": "1.8.2",
   "description": "Electron version of the mksnapshot binary",
   "repository": "https://github.com/electron/mksnapshot",
   "bin": {


### PR DESCRIPTION
## Updated
  * New version is released
    * It is significantly important to MAC user using High sierra with NVIDIA Graphic
      * Fix rendering issues with the Nvidia GPU on High Sierra. #10923
      * https://electronjs.org/releases#1.8.2-beta.3
      * Slack is still slow because they were not patched but i'm not sure they are using this binary
      * VSCode is still using v1.7.0 because v1.8.2 is not released in this repository
        * https://github.com/Microsoft/vscode/blob/master/package.json#L66


## TODO
   * Please tag & release `v1.8.2`

## Release
  * https://github.com/electron/electron/releases/tag/v1.8.2