### PR TITLE
fix: download on arm64 macs

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,3 +75,10 @@ From an Intel x64 Windows OS run:
 npm config set arch arm64
 npm install --save-dev electron-mksnapshot
 ```
+
+### macOS on ARM64
+On macOS you can either run the cross arch mksnapshot directly on arm64 hardware or if you wish you can generate the snapshot on an Intel X64 macOS hardware via the following:
+```sh
+npm config set arch arm64
+npm install --save-dev electron-mksnapshot
+```

--- a/download-mksnapshot.js
+++ b/download-mksnapshot.js
@@ -13,7 +13,7 @@ if (process.arch.indexOf('arm') === 0 && process.platform !== 'darwin') {
 }
 
 if (archToDownload && archToDownload.indexOf('arm') === 0 && process.platform !== 'darwin') {
-    archToDownload += '-x64'  
+  archToDownload += '-x64'
 }
 
 function download (version) {

--- a/download-mksnapshot.js
+++ b/download-mksnapshot.js
@@ -5,22 +5,15 @@ const extractZip = require('extract-zip')
 const versionToDownload = require('./package').version
 let archToDownload = process.env.npm_config_arch
 
-if (process.arch.indexOf('arm') === 0) {
+if (process.arch.indexOf('arm') === 0 && process.platform !== 'darwin') {
   console.log(`WARNING: mksnapshot does not run on ${process.arch}. Download 
   https://github.com/electron/electron/releases/download/v${versionToDownload}/mksnapshot-v${versionToDownload}-${process.platform}-${process.arch}-x64.zip
   on a x64 ${process.platform} OS to generate ${archToDownload} snapshots.`)
   process.exit(1)
 }
 
-if (archToDownload && archToDownload.indexOf('arm') === 0) {
-  if (process.platform !== 'darwin') {
-    archToDownload += '-x64'
-  } else {
-    console.log(`WARNING: mksnapshot for ${archToDownload} is not available on macOS. Download 
-    https://github.com/electron/electron/releases/download/v${versionToDownload}/mksnapshot-v${versionToDownload}-linux-${archToDownload}-x64.zip
-    on a x64 Linux OS to generate ${archToDownload} snapshots.`)
-    process.exit(1)
-  }
+if (archToDownload && archToDownload.indexOf('arm') === 0 && process.platform !== 'darwin') {
+    archToDownload += '-x64'  
 }
 
 function download (version) {


### PR DESCRIPTION
mksnapshot for macOS arm64 is available as an x64 executable that generates arm64 compatible snapshots.  This PR changes electron-mksnapshot to download that version of mksnapshot because it can run on arm64 macs via rosetta.

Fixes #35