### PR TITLE
 chore: update mksnapshot to work with Apple Silicon

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,4 +81,5 @@ On macOS you can either run the cross arch mksnapshot directly on arm64 hardware
 ```sh
 npm config set arch arm64
 npm install --save-dev electron-mksnapshot
+npm run mksnapshot ABSOLUTE_PATH_TO_FILE/file.js -- --output_dir ABSOLUTE_PATH_TO_OUTPUT_DIR
 ```

--- a/mksnapshot.js
+++ b/mksnapshot.js
@@ -88,7 +88,7 @@ if (fs.existsSync(argsFile)) {
 }
 
 const options = {
-  cwd: workingDir,
+  cwd: mksnapshotBinaryDir,
   env: process.env,
   stdio: 'inherit'
 }
@@ -107,13 +107,13 @@ if (args.includes('--help')) {
   process.exit(0)
 }
 
-fs.copyFileSync(path.join(workingDir, 'snapshot_blob.bin'),
+fs.copyFileSync(path.join(mksnapshotBinaryDir, 'snapshot_blob.bin'),
   path.join(outputDir, 'snapshot_blob.bin'))
 
 const v8ContextGenCommand = getBinaryPath('v8_context_snapshot_generator', mksnapshotBinaryDir)
 let v8ContextFile = 'v8_context_snapshot.bin'
 if (process.platform === 'darwin') {
-  const targetArch = process.env.npm_config_arch
+  const targetArch = process.env.npm_config_arch || process.arch
   if (targetArch === 'arm64') {
     v8ContextFile = 'v8_context_snapshot.arm64.bin'
   } else {

--- a/mksnapshot.js
+++ b/mksnapshot.js
@@ -111,8 +111,17 @@ fs.copyFileSync(path.join(workingDir, 'snapshot_blob.bin'),
   path.join(outputDir, 'snapshot_blob.bin'))
 
 const v8ContextGenCommand = getBinaryPath('v8_context_snapshot_generator', mksnapshotBinaryDir)
+let v8ContextFile = 'v8_context_snapshot.bin'
+if (process.platform === 'darwin') {
+  const targetArch = process.env.npm_config_arch
+  if (targetArch === 'arm64') {
+    v8ContextFile = 'v8_context_snapshot.arm64.bin'
+  } else {
+    v8ContextFile = 'v8_context_snapshot.x86_64.bin'
+  }
+}
 const v8ContextGenArgs = [
-  `--output_file=${path.join(outputDir, 'v8_context_snapshot.bin')}`
+  `--output_file=${path.join(outputDir, v8ContextFile)}`
 ]
 
 const v8ContextGenOptions = {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "mksnapshot": "./mksnapshot.js"
   },
   "scripts": {
+    "mksnapshot": "node ./mksnapshot.js",
     "install": "node ./download-mksnapshot.js",
     "test": "mocha && standard"
   },

--- a/test/mksnapshot-test.js
+++ b/test/mksnapshot-test.js
@@ -13,7 +13,16 @@ describe('mksnapshot binary', function () {
   it('creates a snapshot for a valid file', function (done) {
     var tempDir = temp.mkdirSync('mksnapshot-')
     var outputFile = path.join(tempDir, 'snapshot_blob.bin')
-    var v8ContextFile = path.join(tempDir, 'v8_context_snapshot.bin')
+    let v8ContextFileName = 'v8_context_snapshot.bin'
+    if (process.platform === 'darwin') {
+      const targetArch = process.env.npm_config_arch
+      if (targetArch === 'arm64') {
+        v8ContextFileName = 'v8_context_snapshot.arm64.bin'
+      } else {
+        v8ContextFileName = 'v8_context_snapshot.x86_64.bin'
+      }
+    }
+    var v8ContextFile = path.join(tempDir, v8ContextFileName)
     var args = [
       path.join(__dirname, '..', 'mksnapshot.js'),
       path.join(__dirname, 'fixtures', 'snapshot.js'),


### PR DESCRIPTION
mksnapshot for macOS arm64 (Apple Silicon) uses a different file structure than other OSes/arches.  This PR updates mksnapshot to work properly when generating snapshots for macOS arm64.

Resolves #37, but #37 is also dependent on electron/electron#29338 being included in new Electron releases.
