### PR TITLE
chore: 17.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-mksnapshot",
-  "version": "17.0.0",
+  "version": "17.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-mksnapshot",
-  "version": "17.0.0",
+  "version": "17.0.1",
   "description": "Electron version of the mksnapshot binary",
   "repository": "https://github.com/electron/mksnapshot",
   "bin": {


### PR DESCRIPTION
As #56, 17.0.0 does not work with Electron 17.0.1, so this will publish a new version for use with Electron >= 17.0.1

Resolves #56

Alternatively 17.0.1 (or any version for that matter) can be used via:
```sh
# Install mksnapshot for Electron v17.0.1
ELECTRON_CUSTOM_VERSION=17.0.1 npm install
```