### PR TITLE
build: add npm publish step to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,3 +47,7 @@ jobs:
       - name: Create Release
         run: |
           gh release create ${{ github.event.inputs.version }} -t ${{ github.event.inputs.version }}
+      - name: Publish to npm
+        run: npm publish
+        env:
+          NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}


### PR DESCRIPTION
As in title. Before this is used, we'll need to generate an [automation token](https://github.blog/changelog/2020-10-02-npm-automation-tokens/) and set an `NPM_AUTH_TOKEN` secret appropriately.