### PR TITLE
ci: fix AppVeyor config

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,10 +4,10 @@ skip_tags: true
 
 branches:
   only:
-    - master
+    - main
 
 environment:
-  nodejs_version: "10"
+  nodejs_version: "14"
 
 cache:
   - node_modules -> package.json


### PR DESCRIPTION
This stopped being run when the repo was cut over to using `main`. Also bumps the Node version to match the CircleCI config.