### PR TITLE
build: do CFA releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,9 @@ jobs:
           name: Update Version
           command: node script/update-version.js << pipeline.git.tag >>
       - run:
+          name: Confirm Version Updated
+          command: node -e "if (require('./package.json').version === '0.0.0-development') process.exit(1)"
+      - run:
           name: CFA Publish
           command: node script/publish.js
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,10 +46,39 @@ jobs:
     steps:
       - install
       - test
+  release:
+    docker:
+      - image: cimg/node:18.14
+    steps:
+      - checkout
+      - run:
+          name: Install Dependencies
+          command: npm ci
+      - run:
+          name: Obtain Publishing Credentials
+          command: npx @continuous-auth/circleci-oidc-github-auth@1.0.4
+      - run:
+          name: Update Version
+          command: node script/update-version.js << pipeline.git.tag >>
+      - run:
+          name: CFA Publish
+          command: node script/publish.js
 
 workflows:
-  test:
+  test_and_release:
     jobs:
       - test-linux
       - test-mac
       - test-windows
+      # TODO - enable
+      # - release:
+      #     requires:
+      #       - test-linux
+      #       - test-mac
+      #       - test-windows
+      #     filters:
+      #       tags:
+      #         only: /^v.*/
+      #       branches:
+      #         ignore: /.*/
+      #     context: cfa-release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,12 @@ commands:
           keys:
             - v1-dependencies-{{ arch }}-{{ checksum "package-lock.json" }}
             - v1-dependencies-{{ arch }}
+      - when:
+          condition: << pipeline.git.tag >>
+          steps:
+            - run:
+                name: Update Version
+                command: node script/update-version.js << pipeline.git.tag >>
       - run: npm install
       - save_cache:
           paths:
@@ -52,14 +58,14 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Update Version
+          command: node script/update-version.js << pipeline.git.tag >>
+      - run:
           name: Install Dependencies
           command: npm ci
       - run:
           name: Obtain Publishing Credentials
           command: npx @continuous-auth/circleci-oidc-github-auth@1.0.4
-      - run:
-          name: Update Version
-          command: node script/update-version.js << pipeline.git.tag >>
       - run:
           name: Confirm Version Updated
           command: node -e "if (require('./package.json').version === '0.0.0-development') process.exit(1)"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,15 +86,14 @@ workflows:
       - test-linux
       - test-mac
       - test-windows
-      # TODO - enable
-      # - release:
-      #     requires:
-      #       - test-linux
-      #       - test-mac
-      #       - test-windows
-      #     filters:
-      #       tags:
-      #         only: /^v.*/
-      #       branches:
-      #         ignore: /.*/
-      #     context: cfa-release
+      - release:
+          requires:
+            - test-linux
+            - test-mac
+            - test-windows
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/
+          context: cfa-release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,14 @@ commands:
             - run:
                 name: Update Version
                 command: node script/update-version.js << pipeline.git.tag >>
-      - run: npm install
+            - run: npm install
+      - unless:
+          condition: << pipeline.git.tag >>
+          steps:
+            - run:
+                command: npm install
+                environment:
+                  ELECTRON_MKSNAPSHOT_STABLE_FALLBACK: 1
       - save_cache:
           paths:
             - node_modules

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,13 +11,14 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
-  run_tests:
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-    runs-on: ${{ matrix.os }}
+  smoke_test:
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c  # tag: v3.3.0
+      - name: Setup Node.js
+        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c  # tag: v3.6.0
+        with:
+          node-version: "16.19.0"
       - name: Update Version
         run: node script/update-version.js ${{ github.event.inputs.version }}
       - name: Install Dependencies
@@ -26,37 +27,15 @@ jobs:
         run: npm test
   create_new_version:
     runs-on: ubuntu-latest
-    needs: run_tests
+    needs: smoke_test
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c  # tag: v3.3.0
-      - name: Setup Node.js
-        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c  # tag: v3.6.0
-        with:
-          node-version: lts/*
-          registry-url: 'https://registry.npmjs.org'
-      - name: Check npm credentials
-        run: npm whoami
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
-      - name: Set Git Credentials
-        run: |
-          git config user.name electron-bot
-          git config user.email electron@github.com
-      - name: Update Version
-        run: node script/update-version.js ${{ github.event.inputs.version }}
-      - name: Push Update Commit
-        run: |
-          git add .
-          git commit -m "chore: update version to ${{ github.event.inputs.version }}"
-          git push origin main
+      # Tag here, the CircleCI workflow will trigger on the new tag and do the CFA publish
       - name: Push New Tag
         run: |
           git tag ${{ github.event.inputs.version }}
           git push origin ${{ github.event.inputs.version }}
+      # TODO - This creates a draft release at the moment
       - name: Create Release
         run: |
-          gh release create ${{ github.event.inputs.version }} -t ${{ github.event.inputs.version }}
-      - name: Publish to npm
-        run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+          gh release create ${{ github.event.inputs.version }} -t ${{ github.event.inputs.version }} -d

--- a/download-mksnapshot.js
+++ b/download-mksnapshot.js
@@ -5,15 +5,31 @@ const extractZip = require('extract-zip')
 const versionToDownload = require('./package').version
 let archToDownload = process.env.npm_config_arch
 
-if (process.arch.indexOf('arm') === 0 && process.platform !== 'darwin') {
-  console.log(`WARNING: mksnapshot does not run on ${process.arch}. Download 
-  https://github.com/electron/electron/releases/download/v${versionToDownload}/mksnapshot-v${versionToDownload}-${process.platform}-${process.arch}-x64.zip
-  on a x64 ${process.platform} OS to generate ${archToDownload} snapshots.`)
-  process.exit(1)
+// Refs https://github.com/electron/fiddle-core/blob/1ee2d2737f23fd1012917a249a9444b6db89f1d8/src/versions.ts#L47-L57
+function compareVersions (a, b) {
+  const l = a.compareMain(b)
+  if (l) return l
+  // Electron's approach is nightly -> other prerelease tags -> stable,
+  // so force `nightly` to sort before other prerelease tags.
+  const [prea] = a.prerelease
+  const [preb] = b.prerelease
+  if (prea === 'nightly' && preb !== 'nightly') return -1
+  if (prea !== 'nightly' && preb === 'nightly') return 1
+  return a.comparePre(b)
 }
 
-if (archToDownload && archToDownload.indexOf('arm') === 0 && process.platform !== 'darwin') {
-  archToDownload += '-x64'
+// Refs https://github.com/electron/fiddle-core/blob/1ee2d2737f23fd1012917a249a9444b6db89f1d8/src/versions.ts#L152-L160
+function getLatestStable (releases) {
+  const { parse: semverParse } = require('semver')
+  const semvers = releases.map(({ version }) => semverParse(version)).filter((sem) => Boolean(sem))
+  semvers.sort((a, b) => compareVersions(a, b))
+  let stable
+  for (const ver of semvers.values()) {
+    if (ver.prerelease.length === 0) {
+      stable = ver
+    }
+  }
+  return stable
 }
 
 function download (version) {
@@ -28,6 +44,24 @@ function download (version) {
 }
 
 async function attemptDownload (version) {
+  // Fall back to latest stable if there is not a stamped version, for tests
+  if (version === '0.0.0-development') {
+    const fetch = require('node-fetch')
+    const releases = await fetch('https://releases.electronjs.org/releases.json').then(response => response.json())
+    version = getLatestStable(releases).version
+  }
+
+  if (process.arch.indexOf('arm') === 0 && process.platform !== 'darwin') {
+    console.log(`WARNING: mksnapshot does not run on ${process.arch}. Download 
+    https://github.com/electron/electron/releases/download/v${version}/mksnapshot-v${version}-${process.platform}-${process.arch}-x64.zip
+    on a x64 ${process.platform} OS to generate ${archToDownload} snapshots.`)
+    process.exit(1)
+  }
+
+  if (archToDownload && archToDownload.indexOf('arm') === 0 && process.platform !== 'darwin') {
+    archToDownload += '-x64'
+  }
+
   try {
     const targetFolder = path.join(__dirname, 'bin')
     const zipPath = await download(version)

--- a/download-mksnapshot.js
+++ b/download-mksnapshot.js
@@ -46,6 +46,11 @@ function download (version) {
 async function attemptDownload (version) {
   // Fall back to latest stable if there is not a stamped version, for tests
   if (version === '0.0.0-development') {
+    if (!process.env.ELECTRON_MKSNAPSHOT_STABLE_FALLBACK) {
+      console.log('WARNING: mksnapshot in development needs the environment variable ELECTRON_MKSNAPSHOT_STABLE_FALLBACK set')
+      process.exit(1)
+    }
+
     const fetch = require('node-fetch')
     const releases = await fetch('https://releases.electronjs.org/releases.json').then(response => response.json())
     version = getLatestStable(releases).version

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "electron-mksnapshot",
-  "version": "22.0.0",
+  "version": "0.0.0-development",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "electron-mksnapshot",
-      "version": "22.0.0",
+      "version": "0.0.0-development",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -19,7 +19,10 @@
         "mksnapshot": "mksnapshot.js"
       },
       "devDependencies": {
+        "@continuous-auth/client": "^2.2.2",
         "mocha": "^10.1.0",
+        "node-fetch": "^2.6.9",
+        "semver": "^7.3.8",
         "standard": "^14.3.1"
       },
       "engines": {
@@ -44,6 +47,15 @@
         "chalk": "^2.0.0",
         "esutils": "^2.0.2",
         "js-tokens": "^4.0.0"
+      }
+    },
+    "node_modules/@continuous-auth/client": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@continuous-auth/client/-/client-2.2.2.tgz",
+      "integrity": "sha512-DC1+Uor/Unt5UAnW8zAc/V/dwDU/zFksDC+/syA4PGvWg5oVqJGNdCw8lYU2Us3LUHk9ac+dkjCPk/MoHmY+Kw==",
+      "dev": true,
+      "dependencies": {
+        "axios": "^0.27.2"
       }
     },
     "node_modules/@electron/get": {
@@ -314,6 +326,22 @@
         "node": ">=4"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true
+    },
+    "node_modules/axios": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "dev": true,
+      "dependencies": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -528,6 +556,18 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -567,6 +607,15 @@
       },
       "engines": {
         "node": ">=4.8"
+      }
+    },
+    "node_modules/cross-spawn/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
       }
     },
     "node_modules/debug": {
@@ -680,6 +729,15 @@
       "dev": true,
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/detect-node": {
@@ -1504,6 +1562,40 @@
       "integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==",
       "dev": true
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dev": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fs-extra": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
@@ -1616,21 +1708,6 @@
       },
       "engines": {
         "node": ">=10.0"
-      }
-    },
-    "node_modules/global-agent/node_modules/semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-      "optional": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/global-tunnel-ng": {
@@ -2282,7 +2359,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "optional": true,
+      "devOptional": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -2312,6 +2389,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/mimic-fn": {
@@ -2541,6 +2639,26 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
+    "node_modules/node-fetch": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
+      "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
+      "dev": true,
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
@@ -2551,6 +2669,15 @@
         "is-builtin-module": "^1.0.0",
         "semver": "2 || 3 || 4 || 5",
         "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "node_modules/normalize-package-data/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
       }
     },
     "node_modules/normalize-path": {
@@ -3257,12 +3384,18 @@
       "dev": true
     },
     "node_modules/semver": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
-      "dev": true,
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "devOptional": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
       "bin": {
-        "semver": "bin/semver"
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/semver-compare": {
@@ -3636,6 +3769,12 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true
+    },
     "node_modules/tslib": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
@@ -3718,6 +3857,22 @@
       "dependencies": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {
@@ -3824,7 +3979,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "optional": true
+      "devOptional": true
     },
     "node_modules/yargs": {
       "version": "16.2.0",
@@ -3909,6 +4064,15 @@
         "chalk": "^2.0.0",
         "esutils": "^2.0.2",
         "js-tokens": "^4.0.0"
+      }
+    },
+    "@continuous-auth/client": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@continuous-auth/client/-/client-2.2.2.tgz",
+      "integrity": "sha512-DC1+Uor/Unt5UAnW8zAc/V/dwDU/zFksDC+/syA4PGvWg5oVqJGNdCw8lYU2Us3LUHk9ac+dkjCPk/MoHmY+Kw==",
+      "dev": true,
+      "requires": {
+        "axios": "^0.27.2"
       }
     },
     "@electron/get": {
@@ -4121,6 +4285,22 @@
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
     },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true
+    },
+    "axios": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "dev": true,
+      "requires": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      }
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -4288,6 +4468,15 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -4321,6 +4510,14 @@
         "semver": "^5.5.0",
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
       }
     },
     "debug": {
@@ -4408,6 +4605,12 @@
           "dev": true
         }
       }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true
     },
     "detect-node": {
       "version": "2.1.0",
@@ -5048,6 +5251,23 @@
       "integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==",
       "dev": true
     },
+    "follow-redirects": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "dev": true
+    },
+    "form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dev": true,
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      }
+    },
     "fs-extra": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
@@ -5132,17 +5352,6 @@
         "roarr": "^2.15.3",
         "semver": "^7.3.2",
         "serialize-error": "^7.0.1"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "7.3.7",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-          "optional": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        }
       }
     },
     "global-tunnel-ng": {
@@ -5649,7 +5858,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "optional": true,
+      "devOptional": true,
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -5669,6 +5878,21 @@
           "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
           "optional": true
         }
+      }
+    },
+    "mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true
+    },
+    "mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "requires": {
+        "mime-db": "1.52.0"
       }
     },
     "mimic-fn": {
@@ -5844,6 +6068,15 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
+    "node-fetch": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
+      "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
+      "dev": true,
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      }
+    },
     "normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
@@ -5854,6 +6087,14 @@
         "is-builtin-module": "^1.0.0",
         "semver": "2 || 3 || 4 || 5",
         "validate-npm-package-license": "^3.0.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
       }
     },
     "normalize-path": {
@@ -6396,10 +6637,13 @@
       "dev": true
     },
     "semver": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
-      "dev": true
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "devOptional": true,
+      "requires": {
+        "lru-cache": "^6.0.0"
+      }
     },
     "semver-compare": {
       "version": "1.0.0",
@@ -6703,6 +6947,12 @@
         "is-number": "^7.0.0"
       }
     },
+    "tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true
+    },
     "tslib": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
@@ -6772,6 +7022,22 @@
       "requires": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true
+    },
+    "whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "requires": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "which": {
@@ -6856,7 +7122,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "optional": true
+      "devOptional": true
     },
     "yargs": {
       "version": "16.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-mksnapshot",
-  "version": "22.0.0",
+  "version": "0.0.0-development",
   "description": "Electron version of the mksnapshot binary",
   "repository": "https://github.com/electron/mksnapshot",
   "bin": {
@@ -19,7 +19,10 @@
     "temp": "^0.8.3"
   },
   "devDependencies": {
+    "@continuous-auth/client": "^2.2.2",
     "mocha": "^10.1.0",
+    "node-fetch": "^2.6.9",
+    "semver": "^7.3.8",
     "standard": "^14.3.1"
   },
   "standard": {

--- a/script/publish.js
+++ b/script/publish.js
@@ -1,9 +1,10 @@
 // Publish the package in the CWD with an OTP code from CFA
-import { getOtp } from '@continuous-auth/client'
-import { spawnSync } from 'child_process'
+const { getOtp } = require('@continuous-auth/client')
+const { spawnSync } = require('child_process')
 
 async function publish () {
-  spawnSync('npm', ['publish', '--otp', await getOtp()])
+  const { status } = spawnSync('npm', ['publish', '--otp', await getOtp()])
+  process.exit(status)
 }
 
 publish()

--- a/script/publish.js
+++ b/script/publish.js
@@ -1,0 +1,9 @@
+// Publish the package in the CWD with an OTP code from CFA
+import { getOtp } from '@continuous-auth/client'
+import { spawnSync } from 'child_process'
+
+async function publish () {
+  spawnSync('npm', ['publish', '--otp', await getOtp()])
+}
+
+publish()


### PR DESCRIPTION
This repo needs to be switched over to CFA for releases. This PR is an attempt to get us there.

To safely transition, this PR only creates draft GH releases, so a follow-up PR should remove the draft flag once everything has ben confirmed to work as expected.

This PR makes several changes to how this repo works for releases:
* The version in `package.json` in `main` and for GH releases will always be `0.0.0-development`, the same as repos covered by semantic releases
* `download-mksnapshot.js` will fall back to latest stable if the version is `0.0.0-development`, so that tests can run
* `.github/workflows/release.yml` will handle the git tag and GH release
* `.circleci/config.yml` will handle the CFA release, triggering on new git tags