### PR TITLE
build: run all jobs on tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,9 +83,18 @@ jobs:
 workflows:
   test_and_release:
     jobs:
-      - test-linux
-      - test-mac
-      - test-windows
+      - test-linux:
+          filters:
+            tags:
+              only: /.*/
+      - test-mac:
+          filters:
+            tags:
+              only: /.*/
+      - test-windows:
+          filters:
+            tags:
+              only: /.*/
       - release:
           requires:
             - test-linux


### PR DESCRIPTION
Unfortunately [the release job did not trigger](https://app.circleci.com/pipelines/github/electron/mksnapshot/199) for the tag because the jobs it depends on were not marked as being able to run on tags.

Refs https://circleci.com/docs/workflows/#executing-workflows-for-a-git-tag