### PR TITLE
chore: add debugging output to publish script

### DIFF
--- a/script/publish.js
+++ b/script/publish.js
@@ -3,7 +3,8 @@ const { getOtp } = require('@continuous-auth/client')
 const { spawnSync } = require('child_process')
 
 async function publish () {
-  const { status } = spawnSync('npm', ['publish', '--otp', await getOtp()])
+  const { status, stdout } = spawnSync('npm', ['publish', '--otp', await getOtp()])
+  if (status !== 0) console.log(stdout)
   process.exit(status)
 }
 


### PR DESCRIPTION
CFA releases are almost complete but `npm publish` is failing and it's not clear why, so log output in the case of a failure.