### PR TITLE
build: bump CFA publish step timeout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,6 +104,7 @@ jobs:
       - run:
           name: CFA Publish
           command: node script/publish.js
+          no_output_timeout: 30m
 
 workflows:
   test_and_release:


### PR DESCRIPTION
Same change as https://github.com/electron/chromedriver/pull/124