### PR TITLE
ci: roll back to x86 macOS executors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,16 +65,16 @@ workflows:
             parameters:
               executor:
                 - node/linux
-                - node/macos
+                - macos
                 - node/windows
               node-version:
                 - '20.5.1'
                 - '18.17.0'
                 - '16.20.1'
                 - '14.21.3'
-            exclude:
-              - executor: node/macos
-                node-version: '14.21.3'
+            # exclude:
+            #   - executor: node/macos
+            #     node-version: '14.21.3'
           filters:
             tags:
               only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,12 @@ version: 2.1
 orbs:
   node: electronjs/node@2.1.0
 
+executors:
+  macos:
+    macos:
+      xcode: "14.3.0"
+    resource_class: macos.x86.medium.gen2
+
 jobs:
   release:
     docker:


### PR DESCRIPTION
We aren't getting clean runs on the M1 runners for Electron <= 26, so roll back to x86 runners for now and we'll revert this once 29 is released.