### PR TITLE
ci: use macos executor from orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,12 +3,6 @@ version: 2.1
 orbs:
   node: electronjs/node@2.3.0
 
-executors:
-  macos:
-    macos:
-      xcode: "14.3.0"
-    resource_class: macos.x86.medium.gen2
-
 jobs:
   release:
     docker:
@@ -65,16 +59,16 @@ workflows:
             parameters:
               executor:
                 - node/linux
-                - macos
+                - node/macos
                 - node/windows
               node-version:
                 - '20.5.1'
                 - '18.17.0'
                 - '16.20.1'
                 - '14.21.3'
-            # exclude:
-            #   - executor: node/macos
-            #     node-version: '14.21.3'
+            exclude:
+              - executor: node/macos
+                node-version: '14.21.3'
           filters:
             tags:
               only: /.*/


### PR DESCRIPTION
Follow-up to #105 which said we'd revert this once E29 released but I forgot to do it. 🙃