### PR TITLE
ci: improve release workflow input description

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
         version:
-          description: 'version'
+          description: Electron version to use with "v" prefix (e.g. v30.0.0)
           required: true
 
 env:


### PR DESCRIPTION
Same change as https://github.com/electron/chromedriver/pull/143, since these two workflows are the same, that change just never got propagated to here.