### PR TITLE
ci: use GitHub app to tag new release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,9 +7,6 @@ on:
           description: Electron version to use with "v" prefix (e.g. v30.0.0)
           required: true
 
-env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
 jobs:
   test:
     uses: ./.github/workflows/test.yml
@@ -17,11 +14,17 @@ jobs:
       electron-version: ${{ github.event.inputs.version }}
   tag_new_version:
     runs-on: ubuntu-latest
+    environment: deps-releaser
     needs: test
-    permissions:
-      contents: write # for pushing new tag
     steps:
+      - name: Generate GitHub App token
+        uses: electron/github-app-auth-action@384fd19694fe7b6dcc9a684746c6976ad78228ae # v1.1.1
+        id: generate-token
+        with:
+          creds: ${{ secrets.DEPS_RELEASER_GH_APP_CREDS }}
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
       # Tag here, the publish-npm.yml workflow will trigger on the new tag and do the CFA publish
       - name: Push New Tag
         run: |


### PR DESCRIPTION
Third time's the charm, forgot the whole GitHub Actions won't trigger another workflow caveat.