### PR TITLE
ci: expand test matrix to arm64 Windows and Linux

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,7 @@ jobs:
       run:
         shell: bash
     strategy:
+      fail-fast: false
       matrix:
         node-version:
           - '20.16.0'
@@ -34,9 +35,17 @@ jobs:
         os:
           - macos-latest
           - ubuntu-latest
+          - ubuntu-24.04-arm
           - windows-latest
+          - windows-11-arm
         exclude:
           - os: macos-latest
+            node-version: 14.21.3
+          - os: windows-11-arm
+            node-version: 18.20.4
+          - os: windows-11-arm
+            node-version: 16.20.2
+          - os: windows-11-arm
             node-version: 14.21.3
     runs-on: "${{ matrix.os }}"
     steps:


### PR DESCRIPTION
These are now generally available, so expanding our test matrix to ensure we test pulling binaries on these platforms.